### PR TITLE
feat: Add `GraphStats` for intospection into Delaunay triangulation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ name = "cev_metrics"
 crate-type = ["cdylib"]
 
 [dependencies]
-delaunator = { git = "https://github.com/manzt/delaunator-rs.git" }
+delaunator = { git = "https://github.com/manzt/delaunator-rs.git", rev = "c0e718b" }
 numpy = "0.21"
 petgraph = "0.6.3"
-pyo3 = { version = "0.21", features = ["extension-module"] }
+pyo3 = { version = "0.22", features = ["extension-module"] }
 rayon = "1.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ name = "cev_metrics"
 crate-type = ["cdylib"]
 
 [dependencies]
-delaunator = "1.0.2"
+delaunator = { git = "https://github.com/manzt/delaunator-rs.git" }
 numpy = "0.21"
 petgraph = "0.6.3"
 pyo3 = { version = "0.21", features = ["extension-module"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ crate-type = ["cdylib"]
 delaunator = { git = "https://github.com/manzt/delaunator-rs.git", rev = "c0e718b" }
 numpy = "0.21"
 petgraph = "0.6.3"
-pyo3 = { version = "0.22", features = ["extension-module"] }
+pyo3 = { version = "0.21", features = ["extension-module"] }
 rayon = "1.7.0"

--- a/bench/run.py
+++ b/bench/run.py
@@ -1,7 +1,7 @@
+import platform
 import statistics
 import timeit
 import typing
-import platform
 
 import pandas as pd
 from cev_metrics import confusion_and_neighborhood

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,3 +28,28 @@ bench = "python bench/run.py"
 [tool.maturin]
 python-source = "python"
 features = ["pyo3/extension-module"]
+
+[tool.ruff]
+line-length = 88
+exclude = ["bench", "x.py"]
+
+[tool.ruff.lint]
+pydocstyle = { convention = "numpy" }
+select = [
+    "E",    # style errors
+    "W",    # style warnings
+    "F",    # flakes
+    "D",    # pydocstyle
+    "D417", # Missing argument descriptions in Docstrings
+    "I",    # isort
+    "UP",   # pyupgrade
+    "C4",   # flake8-comprehensions
+    "B",    # flake8-bugbear
+    "A001", # flake8-builtins
+    "RUF",  # ruff-specific rules
+    "TCH",  # flake8-type-checking
+    "TID",  # flake8-tidy-imports
+]
+ignore = [
+    "D401", # First line should be in imperative mood (remove to opt in)
+]

--- a/python/cev_metrics/__init__.py
+++ b/python/cev_metrics/__init__.py
@@ -1,18 +1,14 @@
-try:
-    from importlib.metadata import PackageNotFoundError, version
-except ImportError:
-    from importlib_metadata import PackageNotFoundError, version  # type: ignore
+"""cev-metrics: A Python package for computing the metrics used in the CEV project."""
 
-try:
-    __version__ = version("cev-metrics")
-except PackageNotFoundError:
-    __version__ = "uninstalled"
+import importlib.metadata
+
+__version__ = importlib.metadata.version("cev-metrics")
 
 from cev_metrics._rust import (
     confusion,
     confusion_and_neighborhood,
+    graph_stats,
     neighborhood,
-    ambiguous_circumcircle_count,
 )
 
-__all__ = ["confusion", "confusion_and_neighborhood", "neighborhood"]
+__all__ = ["confusion", "confusion_and_neighborhood", "neighborhood", "graph_stats"]

--- a/python/cev_metrics/__init__.py
+++ b/python/cev_metrics/__init__.py
@@ -8,6 +8,11 @@ try:
 except PackageNotFoundError:
     __version__ = "uninstalled"
 
-from cev_metrics._rust import confusion, confusion_and_neighborhood, neighborhood
+from cev_metrics._rust import (
+    confusion,
+    confusion_and_neighborhood,
+    neighborhood,
+    ambiguous_circumcircle_count,
+)
 
 __all__ = ["confusion", "confusion_and_neighborhood", "neighborhood"]

--- a/python/cev_metrics/_py.py
+++ b/python/cev_metrics/_py.py
@@ -1,6 +1,8 @@
+"""Deprecated python fuctions for prior to porting to Rust."""
+
 import heapq
-from dataclasses import dataclass
 from collections import deque
+from dataclasses import dataclass
 
 import matplotlib.pyplot as plt
 import networkx as nx
@@ -38,13 +40,13 @@ def create_delaunay_graph(X: np.ndarray, clip: str = "convex hull"):
     nx.Graph
         A networkx graph representing the Delaunay graph.
     """
-
     cells, _ = voronoi_frames(X, clip=clip)
     delaunay = weights.Rook.from_dataframe(cells)
     return delaunay.to_networkx()
 
 
 def plot_delaunay(df: str | pd.DataFrame, ax=None, with_graph=True):
+    """Plot a Delaunay graph."""
     ax = ax or plt.gca()
     if isinstance(df, str):
         df = pd.read_parquet(f"../task2/parquet/{df}.parquet")
@@ -129,6 +131,7 @@ def bfs(graph: nx.Graph, start: int, max_depth: int):
         The node to start the search from.
     max_depth : int
         The maximum depth to search.
+
     Returns
     -------
     set[int]
@@ -217,7 +220,9 @@ def find_label_confusion(
         An array of shape (n,) of labels.
     graph : nx.Graph
         The graph to search.
-    depth_confusion : int, optional
+    label : str
+        The label to find the confusion set for.
+    max_depth : int, optional
         The maximum depth to search, by default 1.
     prune_factor : float, optional
         A factor to prune the search, by default 2. This is multiplied by the standard
@@ -286,6 +291,7 @@ def create_confusion_matrix(df: pd.DataFrame, infos: dict[str, ConfusionResult])
 
 
 def map_range(distances: np.ndarray, min_val: float, max_val: float):
+    """Map the distances to a range between 0 and 1."""
     out = (max_val - distances) / (max_val - min_val)
     out[distances > max_val] = 0
     out[distances < min_val] = 1
@@ -300,6 +306,7 @@ def find_label_neighborhood(
     scale: tuple[float, float],
     depth_limit: int,
 ):
+    """Find the neighborhood for a label."""
     boundary_edges = confusion_result.boundary_edges
     if len(boundary_edges) == 0:
         return []
@@ -334,6 +341,7 @@ def find_neighborhoods(
     scale: tuple[float | None, float | None] = (None, None),
     **kwargs,
 ):
+    """Find the neighborhood for each label."""
     unique_labels = np.unique(labels)
 
     if confusion_results is None:
@@ -375,6 +383,7 @@ def find_neighborhoods(
 
 
 def neighborhood(df: pd.DataFrame, **kwargs):
+    """Find the neighborhood for each label in the dataframe."""
     points = df[["x", "y"]].to_numpy()
     labels = df["label"].to_numpy()
     graph = create_delaunay_graph(points)
@@ -392,9 +401,10 @@ def confusion(df: pd.DataFrame, counts: bool = False, **kwargs):
         If True, returns the full confusion matrix as a DataFrame, where
         each row is a count vector of the confusion set for a label.
         If False, returns a Series of confusion scores.
+    kwargs : dict
+        Additional keyword arguments for the confusion set.
 
     """
-
     points = df[["x", "y"]].to_numpy()
     labels = df["label"].to_numpy()
     graph = create_delaunay_graph(points)
@@ -416,6 +426,7 @@ def confusion_neighborhood(
     confusion_kwargs: None | dict = None,
     neighborhood_kwargs: None | dict = None,
 ):
+    """Find the confusion set and neighborhood for each label in the dataframe."""
     points = df[["x", "y"]].to_numpy()
     labels = df["label"].to_numpy()
     graph = create_delaunay_graph(points)
@@ -440,6 +451,7 @@ def confusion_neighborhood(
 
 
 def summarize_neighborhood(boundaries):
+    """Summarize the neighborhood results into a DataFrame."""
     d = pd.DataFrame.from_records(boundaries, columns=["count", "weight", "dist"])
     df = pd.concat(
         [d["count"].value_counts(), d.groupby(["count"]).mean()["dist"]], axis=1
@@ -449,6 +461,7 @@ def summarize_neighborhood(boundaries):
 
 
 def process_neighborhood(nresult):
+    """Process the neighborhood results into a DataFrame."""
     dfs = []
     for b in nresult.values():
         dfs.append(summarize_neighborhood(b))
@@ -489,7 +502,7 @@ def count_bits(uint: np.ndarray):
     return bits.sum(axis=2)
 
 
-def jaccard_distance(v1: np.ndarray, v2: np.ndarray, **kwargs):
+def jaccard_distance(v1: np.ndarray, v2: np.ndarray):
     """Compute the Jaccard distance between two uint8 arrays using bit operations.
 
     Parameters
@@ -498,6 +511,8 @@ def jaccard_distance(v1: np.ndarray, v2: np.ndarray, **kwargs):
         Array of uint8 values.
     v2 : np.ndarray
         Array of uint8 values.
+    kwargs : dict
+        Additional keyword arguments.
 
     Returns
     -------
@@ -517,15 +532,15 @@ def jaccard_distance(v1: np.ndarray, v2: np.ndarray, **kwargs):
     return 1 - (intersection / union)
 
 
-def hamming_distance(v1: np.ndarray, v2: np.ndarray, **kwargs):
+def hamming_distance(v1: np.ndarray, v2: np.ndarray):
     """Compute the Hamming distance between two uint8 arrays using bit operations.
 
     Parameters
     ----------
-        v1 : np.ndarray
-            Array of uint8 values.
-        v2 : np.ndarray
-            Array of uint8 values.
+    v1 : np.ndarray
+        Array of uint8 values.
+    v2 : np.ndarray
+        Array of uint8 values.
 
     Returns
     -------

--- a/python/cev_metrics/_rust.py
+++ b/python/cev_metrics/_rust.py
@@ -70,6 +70,19 @@ def confusion_and_neighborhood(df: pd.DataFrame, max_depth: int = 1):
 
 @dataclass
 class GraphStats:
+    """Statistics from building the Delaunay triangulation.
+
+    Attributes
+    ----------
+    triangle_count : int
+        Number of triangles in the graph.
+
+    ambiguous_circumcircle_count : int
+        The number of occurrences where four or more points lie on the same
+        circumcircle, resulting in an ambiguous triangulation with
+        identical circumcenters.
+    """
+
     triangle_count: int
     ambiguous_circumcircle_count: int
 

--- a/python/cev_metrics/_rust.py
+++ b/python/cev_metrics/_rust.py
@@ -9,17 +9,22 @@ from cev_metrics.cev_metrics import (
 )
 
 
-def _prepare(df: pd.DataFrame):
+def _prepare_xy(df: pd.DataFrame) -> Graph:
     points = df[["x", "y"]].values
-    codes = df["label"].cat.codes.values
 
     if points.dtype != np.float64:
         points = points.astype(np.float64)
 
+    return Graph(points)
+
+
+def _prepare_labels(df: pd.DataFrame) -> np.ndarray:
+    codes = df["label"].cat.codes.values
+
     if codes.dtype != np.int16:
         codes = codes.astype(np.int16)
 
-    return Graph(points), codes
+    return codes
 
 
 def confusion(df: pd.DataFrame):
@@ -30,8 +35,7 @@ def confusion(df: pd.DataFrame):
     df : pd.DataFrame
         Dataframe with columns `x`, `y` and `label`. `label` must be a categorical.
     """
-    graph, codes = _prepare(df)
-    return _confusion(graph, codes)
+    return _confusion(_prepare_xy(df), _prepare_labels(df))
 
 
 def neighborhood(df: pd.DataFrame, max_depth: int = 1):
@@ -45,8 +49,7 @@ def neighborhood(df: pd.DataFrame, max_depth: int = 1):
     max_depth : int, optional
         Maximum depth (or hops) to consider for neighborhood metric. Default is 1.
     """
-    graph, codes = _prepare(df)
-    return _neighborhood(graph, codes, max_depth)
+    return _neighborhood(_prepare_xy(df), _prepare_labels(df))
 
 
 def confusion_and_neighborhood(df: pd.DataFrame, max_depth: int = 1):
@@ -60,5 +63,15 @@ def confusion_and_neighborhood(df: pd.DataFrame, max_depth: int = 1):
     max_depth : int, optional
         Maximum depth (or hops) to consider for neighborhood metric. Default is 1.
     """
-    graph, codes = _prepare(df)
-    return _confusion_and_neighborhood(graph, codes, max_depth)
+    return _confusion_and_neighborhood(_prepare_xy(df), _prepare_labels(df), max_depth)
+
+
+def ambiguous_circumcircle_count(df: pd.DataFrame):
+    """Returns the number of ambiguous circumcircles found in the Delaunay triangulation.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Dataframe with columns `x`, `y` and `label`. `label` must be a categorical.
+    """
+    return _prepare_xy(df).ambiguous_circumcircle_count()

--- a/python/cev_metrics/_rust.py
+++ b/python/cev_metrics/_rust.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass
+
 import numpy as np
 import pandas as pd
 
@@ -66,12 +68,16 @@ def confusion_and_neighborhood(df: pd.DataFrame, max_depth: int = 1):
     return _confusion_and_neighborhood(_prepare_xy(df), _prepare_labels(df), max_depth)
 
 
-def ambiguous_circumcircle_count(df: pd.DataFrame):
-    """Returns the number of ambiguous circumcircles found in the Delaunay triangulation.
+@dataclass
+class GraphStats:
+    triangle_count: int
+    ambiguous_circumcircle_count: int
 
-    Parameters
-    ----------
-    df : pd.DataFrame
-        Dataframe with columns `x`, `y` and `label`. `label` must be a categorical.
-    """
-    return _prepare_xy(df).ambiguous_circumcircle_count()
+
+def graph_stats(df: pd.DataFrame):
+    """Returns statistics from building the Delaunay triangulation."""
+    graph = _prepare_xy(df)
+    return GraphStats(
+        triangle_count=graph.triangle_count(),
+        ambiguous_circumcircle_count=graph.ambiguous_circumcircle_count(),
+    )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,6 +271,7 @@ struct Graph {
     graph: UnGraph<usize, f64>,
     points: Vec<Point>,
     ambiguous_circumcircle_count: usize,
+    triangle_count: usize,
 }
 
 impl From<&Vec<Point>> for Graph {
@@ -279,7 +280,7 @@ impl From<&Vec<Point>> for Graph {
             std::iter::repeat(Element::Node { weight: 0 }).take(points.len()),
         );
         let triangulation = triangulate(points);
-        for triangle in triangulate(points).triangles.chunks(3) {
+        for triangle in triangulation.triangles.chunks(3) {
             let (a, b, c) = (triangle[0], triangle[1], triangle[2]);
             // `update_edge` avoids adding duplicate edges
             graph.update_edge(
@@ -301,7 +302,8 @@ impl From<&Vec<Point>> for Graph {
         Self {
             graph,
             points: points.clone(),
-            ambiguous_circumcircle_count: triangulation.ambiguous_circumcircle_count
+            ambiguous_circumcircle_count: triangulation.ambiguous_circumcircle_count,
+            triangle_count: triangulation.triangles.len() / 3,
         }
     }
 }
@@ -359,6 +361,10 @@ impl Graph {
 
     fn ambiguous_circumcircle_count(&self) -> usize {
         self.ambiguous_circumcircle_count
+    }
+
+    fn triangle_count(&self) -> usize {
+        self.triangle_count
     }
 
     fn __repr__(&self) -> String {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,6 +270,7 @@ impl<'a> Labels<'a> {
 struct Graph {
     graph: UnGraph<usize, f64>,
     points: Vec<Point>,
+    ambiguous_circumcircle_count: usize,
 }
 
 impl From<&Vec<Point>> for Graph {
@@ -277,6 +278,7 @@ impl From<&Vec<Point>> for Graph {
         let mut graph = UnGraph::<_, _>::from_elements(
             std::iter::repeat(Element::Node { weight: 0 }).take(points.len()),
         );
+        let triangulation = triangulate(points);
         for triangle in triangulate(points).triangles.chunks(3) {
             let (a, b, c) = (triangle[0], triangle[1], triangle[2]);
             // `update_edge` avoids adding duplicate edges
@@ -299,6 +301,7 @@ impl From<&Vec<Point>> for Graph {
         Self {
             graph,
             points: points.clone(),
+            ambiguous_circumcircle_count: triangulation.ambiguous_circumcircle_count
         }
     }
 }
@@ -352,6 +355,10 @@ impl Graph {
     #[new]
     fn py_new(coords: PyReadonlyArray2<'_, f64>) -> PyResult<Self> {
         Ok(Graph::from(&coords))
+    }
+
+    fn ambiguous_circumcircle_count(&self) -> usize {
+        self.ambiguous_circumcircle_count
     }
 
     fn __repr__(&self) -> String {

--- a/x.py
+++ b/x.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+"""A simple test script to test the Rust impl."""
 
 import pandas as pd
 from cev_metrics import confusion_and_neighborhood
@@ -7,6 +8,7 @@ from cev_metrics import confusion_and_neighborhood
 
 
 def main():
+    """Test the confusion_and_neighborhood function."""
     df = pd.DataFrame(
         {
             "x": [0.0, 0.0, 1.0, 1.0],


### PR DESCRIPTION
Depends on a fork of https://github.com/manzt/delaunator-rs, which includes functionality to count the number of times co-circular points occur when making the Delaunay triangulation (i.e., an ambiguous circumcircle).
