### PR TITLE
Support Python 3.13+ via abi3 stable ABI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 delaunator = { git = "https://github.com/manzt/delaunator-rs.git", rev = "c0e718b" }
-numpy = "0.21"
+numpy = "0.28"
 petgraph = "0.6.3"
-pyo3 = { version = "0.21", features = ["extension-module"] }
+pyo3 = { version = "0.28", features = ["extension-module", "abi3-py39"] }
 rayon = "1.7.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -393,7 +393,7 @@ fn cev_metrics(m: &Bound<'_, PyModule>) -> PyResult<()> {
     ) -> Bound<'py, PyArray2<u64>> {
         let labels = Labels::from_codes(codes.as_slice().unwrap());
         let confusion = labels.confusion(graph);
-        confusion.counts().into_pyarray_bound(py)
+        confusion.counts().into_pyarray(py)
     }
 
     #[pyfn(m, name="_neighborhood", signature=(graph, codes, max_depth=1))]
@@ -406,7 +406,7 @@ fn cev_metrics(m: &Bound<'_, PyModule>) -> PyResult<()> {
         let labels = Labels::from_codes(codes.as_slice().unwrap());
         let confusion = labels.confusion(graph);
         let neighborhood = labels.neighborhood(graph, &confusion, max_depth);
-        neighborhood.scores().into_pyarray_bound(py)
+        neighborhood.scores().into_pyarray(py)
     }
 
     #[pyfn(m, name="_confusion_and_neighborhood", signature=(graph, codes, neighborhood_max_depth=1))]
@@ -420,8 +420,8 @@ fn cev_metrics(m: &Bound<'_, PyModule>) -> PyResult<()> {
         let confusion = labels.confusion(graph);
         let neighborhood = labels.neighborhood(graph, &confusion, neighborhood_max_depth);
         (
-            confusion.counts().into_pyarray_bound(py),
-            neighborhood.scores().into_pyarray_bound(py),
+            confusion.counts().into_pyarray(py),
+            neighborhood.scores().into_pyarray(py),
         )
     }
 


### PR DESCRIPTION
## Summary

Released wheels currently top out at Python 3.12. `pyo3 0.21` and `numpy 0.21` predate Python 3.13/3.14 and won't compile against them.

This PR bumps both crates to 0.28 and enables the `abi3-py39` stable-ABI feature. From here forward, one wheel per platform covers Python 3.9 and every future 3.x release without CI changes for each new Python.

## Design decision

Going abi3 instead of just adding 3.13/3.14 to the matrix.

- Drops the build matrix from `N python versions × M platforms` to `M platforms`.
- Each future Python release works on the published wheels with no rebuild.
- `cev-metrics` doesn't use version-specific pyo3 APIs, so the abi3 ceiling isn't a constraint.

## Code changes

- `Cargo.toml`: pyo3 `0.21` → `0.28`, numpy `0.21` → `0.28`, add `abi3-py39` to pyo3 features.
- `src/lib.rs`: numpy renamed `into_pyarray_bound` → `into_pyarray` now that `Bound` is the only return form.

CI is unchanged. `maturin` detects the abi3 feature and emits one `cp39-abi3-*` wheel per platform regardless of `--find-interpreter`.

## Verification

Built locally with maturin against Python 3.14 and confirmed the resulting `cev_metrics-0.1.5-cp39-abi3-macosx_11_0_arm64.whl` imports and runs on both 3.13.12 and 3.14.4. `confusion`, `neighborhood`, `confusion_and_neighborhood`, and `graph_stats` all return expected shapes against a random `pd.DataFrame`.

## Test plan

- [ ] CI builds wheels on all target platforms.
- [ ] Resulting wheels are tagged `cp39-abi3-<platform>` (one per platform, not per Python version).
- [ ] `pip install` succeeds on a Python 3.13 and 3.14 interpreter.
